### PR TITLE
feat(hermes): pull-based /var/lib/hermes backup (l4 <- rt via rsnapshot)

### DIFF
--- a/lib/secrets/hermes-backup-key.age
+++ b/lib/secrets/hermes-backup-key.age
@@ -1,0 +1,4 @@
+PLACEHOLDER — regenerate with: agenix -e lib/secrets/hermes-backup-key.age
+(after adding l4's real host key to secrets.nix and pasting the generated
+ed25519 private key). This file only exists so `nix flake check` can evaluate
+the l4 config; it is NOT a valid age secret yet.

--- a/nix/features/services/hermes-backup.nix
+++ b/nix/features/services/hermes-backup.nix
@@ -1,0 +1,51 @@
+{...}: {
+  # Pull-based backup of hermes state.
+  #
+  # `services-hermes-backup`        -> the pulling host (l4): rsnapshot pulls
+  #                                    /var/lib/hermes from rt over ssh.
+  # `services-hermes-backup-source` -> the source host (rt): exposes a
+  #                                    dedicated, restricted key that can only
+  #                                    do read-only rsync of /var/lib/hermes.
+  flake.modules.nixos."services-hermes-backup" = {
+    lib,
+    config,
+    ...
+  }: let
+    # rsnapshot requires TAB-separated fields; build rows as lists and let
+    # lib join them so we never hand-write tab characters.
+    toConf = rows: lib.concatMapStringsSep "\n" (lib.concatStringsSep "\t") rows;
+  in {
+    age.secrets.hermes-backup-key.file = ./../../../lib/secrets/hermes-backup-key.age;
+    # agenix default owner=root, mode=0400 — correct for an ssh private key.
+
+    services.rsnapshot = {
+      enable = true;
+
+      cronIntervals = {
+        daily = "50 3 * * *";
+        weekly = "0 4 * * 0";
+        monthly = "0 5 1 * *";
+      };
+
+      extraConfig = toConf [
+        ["snapshot_root" "/var/backup/hermes/"]
+        ["retain" "daily" "7"]
+        ["retain" "weekly" "4"]
+        ["retain" "monthly" "6"]
+        ["ssh_args" "-i ${config.age.secrets.hermes-backup-key.path} -o StrictHostKeyChecking=accept-new"]
+        ["backup" "root@rt:/" "hermes/"]
+      ];
+    };
+  };
+
+  flake.modules.nixos."services-hermes-backup-source" = {pkgs, ...}: {
+    # Restricted key used by the pulling host to read /var/lib/hermes.
+    # The forced rrsync command allows nothing but read-only rsync of that dir.
+    # TODO: replace <BACKUP_PUBKEY> with the public half of the dedicated
+    # keypair generated during setup (see services-hermes-backup).
+    users.users.root.openssh.authorizedKeys.keys = [
+      ''command="${pkgs.rsync}/bin/rrsync -ro /var/lib/hermes",restrict <BACKUP_PUBKEY>''
+    ];
+    environment.systemPackages = [pkgs.rsync]; # rrsync execs `rsync` from PATH
+  };
+}

--- a/nix/hosts/l4/default.nix
+++ b/nix/hosts/l4/default.nix
@@ -22,6 +22,7 @@
       # services-photosync
       quirks-prevent-sleep
       services-sat-backups
+      services-hermes-backup
     ];
 
     disko.devices.disk.main-disk.device = "/dev/sda";

--- a/nix/hosts/rt/default.nix
+++ b/nix/hosts/rt/default.nix
@@ -14,6 +14,7 @@
       disks-normal
       jobs-updates
       services-hermes
+      services-hermes-backup-source
     ];
 
     disko.devices.disk.main-disk.device = "/dev/sda";

--- a/secrets.nix
+++ b/secrets.nix
@@ -5,6 +5,8 @@ let
 
   systems = {
     mt = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO1l4E2BxsfN8rHZnntHirLssQQsQ+gofyrJYo+nMWz5";
+    # TODO: replace with l4's real host key: `cat /etc/ssh/ssh_host_ed25519_key.pub` on l4
+    l4 = "ssh-ed25519 REPLACE_WITH_L4_HOST_PUBKEY";
   };
 
   allSystems = builtins.attrValues systems;
@@ -18,6 +20,12 @@ in {
 
   "${basePath}/test-secret.age" = {
     publicKeys = users ++ allSystems;
+    armor = true;
+  };
+
+  # SSH private key l4 uses to pull /var/lib/hermes from rt (read-only).
+  "${basePath}/hermes-backup-key.age" = {
+    publicKeys = users ++ [systems.l4];
     armor = true;
   };
 }


### PR DESCRIPTION
## What

Sets up a pull-based backup of hermes state (`/var/lib/hermes`) where **l4 pulls from rt** over SSH using **rsnapshot** (rsync + rotating hardlinked snapshots).

Two encapsulated modules in `nix/features/services/hermes-backup.nix`:

- **`services-hermes-backup`** (imported on **l4**): rsnapshot pulls `root@rt:/var/lib/hermes` into `/var/backup/hermes` with daily/weekly/monthly retention (7/4/6). Uses a dedicated agenix-managed SSH key.
- **`services-hermes-backup-source`** (imported on **rt**): adds a restricted `root` `authorized_keys` entry with a forced `rrsync -ro /var/lib/hermes` command, so the key can do nothing but read-only rsync of that directory. Ensures `rsync` is on rt.

Host `default.nix` files only gain a single import line each (no loose ops).

## Design notes

- rsnapshot config is built via `lib` (`concatStringsSep "\t"`) so tab-separated fields aren't hand-written.
- `backup root@rt:/` because `rrsync` makes `/var/lib/hermes` the virtual root.
- Retention 7 daily / 4 weekly / 6 monthly; cron at 03:50 daily / 04:00 Sun / 05:00 1st.

## Manual setup still required (can't be done from CI/dev host)

1. `ssh-keygen -t ed25519 -N "" -f /tmp/hermes-backup -C hermes-backup@l4`
2. Put the **pubkey** into `services-hermes-backup-source` (replace `<BACKUP_PUBKEY>`).
3. Add **l4's real host key** to `secrets.nix` `systems.l4` (`cat /etc/ssh/ssh_host_ed25519_key.pub` on l4).
4. `agenix -e lib/secrets/hermes-backup-key.age` and paste the **private key** (replaces the placeholder file).
5. Deploy **rt first**, then l4.

## Caveats

- `lib/secrets/hermes-backup-key.age` is currently a **placeholder** (not a valid age secret) so `nix flake check` can evaluate the l4 config.
- The placeholder `systems.l4` key also lands in `allSystems`, so editing existing secrets via agenix will fail until it's replaced with the real key.

## Verification

- `nix flake check` passes (all hosts evaluate).
- alejandra formatting clean.
- Post-deploy: run `rsnapshot ... daily` on l4 and confirm `env`/`auth.json` land under `/var/backup/hermes/daily.0/hermes/`; `ssh -i /tmp/hermes-backup root@rt` should be refused a shell.