### PR TITLE
ci: modernize and harden gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,12 +1,16 @@
 name: Gitleaks
 on: [pull_request, push, workflow_dispatch]
+
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Summary
- update the Gitleaks workflow to use `actions/checkout@v4`
- restrict the workflow token to read-only repository contents, following least privilege

## Testing
- `nix run nixpkgs#actionlint -- .github/workflows/gitleaks.yml`
- `nix flake check --all-systems`
- `git diff --check`