### PR TITLE
security: restrict sat token permissions

### DIFF
--- a/bin/sat/sat-login
+++ b/bin/sat/sat-login
@@ -1,19 +1,22 @@
 #!/usr/bin/env sh
 
 set -e
+umask 077
 
 state=$(sat-state-dir)
 
 [ ! -d "$state" ] && mkdir -pv "$state"
+chmod a-s,u=rwx,go= "$state"
 
 if [ ! -f "$state/url" ]; then
     base_url=$(gum input --placeholder 'Base url' --no-show-help)
-    echo "$base_url" >"$state/url"
+    printf '%s\n' "$base_url" >"$state/url"
 fi
 
 [ -f "$state/token" ] && gum log --level warn 'Token is already defined'
 
 token=$(gum input --placeholder 'Token' --no-show-help)
-echo "$token" >"$state/token"
+printf '%s\n' "$token" >"$state/token"
+chmod 600 "$state/token"
 
 gum log --level info 'Token added successfuly'


### PR DESCRIPTION
## Summary
- store SAT Journal state in an owner-only directory
- create the bearer token with owner-only permissions and tighten existing state directories

## Testing
- `nix run nixpkgs#shfmt -- -d bin/sat/sat-login`
- `nix run nixpkgs#shellcheck -- -s sh bin/sat/sat-login`
- mocked `sat-login` permission regression test (verifies state directory `0700` and token `0600`)
- `git diff --check`