### PR TITLE
security: restrict flake check token permissions

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: cachix/install-nix-action@v27
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '**.nix'
       - 'flake.lock'
+
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- explicitly restrict the Flake check workflow token to read-only repository contents
- prevent `actions/checkout` from persisting that token in the local Git configuration before Nix evaluation
- preserve the workflow’s checkout and Nix evaluation behavior while enforcing least privilege

## Testing
- `nix run nixpkgs#actionlint -- .github/workflows/flake-check.yml`
- `git diff --check`