### PR TITLE
security: protect sat token state directory

### DIFF
--- a/bin/sat/sat-login
+++ b/bin/sat/sat-login
@@ -4,7 +4,8 @@ set -e
 
 state=$(sat-state-dir)
 
-[ ! -d "$state" ] && mkdir -pv "$state"
+mkdir -p -m 700 "$state"
+chmod 700 "$state"
 
 if [ ! -f "$state/url" ]; then
     base_url=$(gum input --placeholder 'Base url' --no-show-help)


### PR DESCRIPTION
## Summary
- create the SAT journal state directory with owner-only permissions
- correct permissions on an existing state directory before storing the bearer token

## Testing
- `sh -n bin/sat/sat-login`
- `nix shell nixpkgs#shfmt -c shfmt -d bin/sat/sat-login`
- `nix flake check --no-build --all-systems`
- `git diff --check`