### PR TITLE
security: avoid persisting gitleaks workflow token

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- prevent `actions/checkout` from persisting the workflow token in Git configuration before Gitleaks runs
- retain the explicit `GITHUB_TOKEN` environment variable required by the Gitleaks action

## Testing
- `nix run nixpkgs#actionlint -- .github/workflows/gitleaks.yml`
- `git diff --check`