### PR TITLE
security: avoid persisting flake update token

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27


### PR DESCRIPTION
## Summary
- prevent the scheduled Flake update checkout from persisting its write-scoped workflow token in local Git configuration
- retain the job-level `contents: write` permission used by the auto-commit action

## Testing
- `nix run nixpkgs#actionlint -- .github/workflows/flake-update.yml`
- `git diff --check`