### PR TITLE
security: disable Composer credential storage

### DIFF
--- a/home/.config/composer/composer.json
+++ b/home/.config/composer/composer.json
@@ -17,6 +17,6 @@
     },
     "config": {
         "use-parent-dir": true,
-        "store-auths": true
+        "store-auths": false
     }
 }


### PR DESCRIPTION
## Summary
- disable Composer credential persistence in the stowed global Composer configuration
- avoid writing repository credentials to the local Composer auth store by default

## Testing
- `python3 -m json.tool home/.config/composer/composer.json`
- `nix run nixpkgs#phpPackages.composer -- --working-dir=home/.config/composer validate --no-check-publish`
- `nix run nixpkgs#phpPackages.composer -- --working-dir=home/.config/composer config store-auths`
- `git diff --check`