### PR TITLE
docs: verify host keys from trusted access

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,15 @@ agenix --rekey
 
 #### Get host key
 
+Read the host's Ed25519 public key from its console or another trusted session.
+Verify its fingerprint before adding it to `secrets.nix`:
+
 ```sh
-ssh-keyscan __host__
+sudo cat /etc/ssh/ssh_host_ed25519_key.pub
+sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
 ```
+
+Do not rely on an unverified `ssh-keyscan` result when enrolling a host key.
 
 ### Troubleshooting auto-upgrade
 


### PR DESCRIPTION
## Summary
- replace the unverified `ssh-keyscan` host-key enrollment instruction with trusted-console retrieval
- document fingerprint verification before adding an Ed25519 host key to `secrets.nix`

## Testing
- `bash -n` validated the documented command sequence
- `nix run nixpkgs#gitleaks -- detect --no-git --source README.md --redact --no-banner`
- `git diff --check`
- `nix run nixpkgs#markdownlint-cli2 -- README.md` reports four pre-existing README style violations outside this change; this hunk introduces none.