### PR TITLE
tmux: background jobs

### DIFF
--- a/bin/dot/init-dirs
+++ b/bin/dot/init-dirs
@@ -8,7 +8,7 @@ cd "$HOME"
 mkdir -pv \
     .config/{docker,docker-darwin,autorandr,systemd/user,composer} \
     .local/{share,bin,sbin} \
-    .local/state/{bash,zsh} \
+    .local/state/{bash,zsh,tmux-jobs} \
     .local/state/sessions/{llm,calc} \
     .gnupg \
     .claude \

--- a/bin/tmux/tmux-bg
+++ b/bin/tmux/tmux-bg
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Move tmux panes to a hidden holding session and manage them as background jobs
+
+set -eu
+
+holder=_bg
+state_dir="$HOME/.local/state/tmux-jobs"
+scope_file="$state_dir/.scope"
+
+# Records are separated by US rather than tab: tab counts as IFS whitespace,
+# so runs of them collapse and empty fields would shift every later field
+sep=$'\x1f'
+
+c_reset=$'\033[0m'
+c_gray=$'\033[90m'
+c_blue=$'\033[34m'
+c_pink=$'\033[35m'
+c_yellow=$'\033[33m'
+
+# Human readable duration, e.g. 1h2m3s
+duration() {
+    local -i secs=${1:-0} h m s
+    ((secs < 0)) && secs=0
+    h=$((secs / 3600))
+    m=$(((secs % 3600) / 60))
+    s=$((secs % 60))
+    local out=""
+    ((h)) && out+="${h}h"
+    ((m)) && out+="${m}m"
+    printf '%s%ss' "$out" "$s"
+}
+
+# Name of the shell panes are started with, used to tell idle from busy
+job_shell=""
+shell_name() {
+    if [[ -z $job_shell ]]; then
+        job_shell=$(tmux show-options -gv default-shell 2>/dev/null) || job_shell=${SHELL:-/bin/sh}
+        job_shell=${job_shell##*/}
+    fi
+    printf '%s' "$job_shell"
+}
+
+# Classify a job, setting job_icon, job_colour, job_detail and job_done.
+# Precedence: dead pane > shell integration state > running command.
+read_state() {
+    local pane=$1 dead=$2 dead_status=$3 cmd=$4 since=$5
+    local kind ts exit_code dur text parked=""
+
+    job_done=0
+    kind=""
+
+    # Only shown where there is no more precise timestamp to report
+    [[ -n $since ]] && parked=" ${c_gray}· $(duration $((EPOCHSECONDS - since))) in bg${c_reset}"
+
+    if [[ $dead == 1 ]]; then
+        job_icon='†'
+        job_colour=$c_yellow
+        job_detail="exited ${dead_status:-?}$parked"
+        job_done=1
+        return 0
+    fi
+
+    [[ -r $state_dir/$pane ]] \
+        && IFS=$sep read -r kind ts exit_code dur text <"$state_dir/$pane" || true
+
+    case $kind in
+        R)
+            job_icon='●'
+            job_colour=$c_gray
+            job_detail="$text ${c_gray}· $(duration $((EPOCHSECONDS - ${ts:-0})))${c_reset}"
+            ;;
+        D)
+            job_done=1
+            if [[ ${exit_code:-0} == 0 ]]; then
+                job_icon='✓'
+                job_colour=$c_blue
+                job_detail="$text"
+            else
+                job_icon='✗'
+                job_colour=$c_pink
+                job_detail="$text ${c_pink}exit $exit_code${c_reset}"
+            fi
+            job_detail+=" ${c_gray}· $(duration "${dur:-0}") · $(duration $((EPOCHSECONDS - ${ts:-0}))) ago${c_reset}"
+            ;;
+        *)
+            # No shell integration data, fall back to the running command
+            if [[ $cmd == "$(shell_name)" ]]; then
+                job_icon='○'
+                job_colour=$c_gray
+                job_detail="idle$parked"
+                job_done=1
+            else
+                job_icon='●'
+                job_colour=$c_gray
+                job_detail="$cmd$parked"
+            fi
+            ;;
+    esac
+
+    return 0
+}
+
+# Emit one record per background job in scope
+records() {
+    local scope=$1 id origin name cmd dead dead_status since format
+
+    format="#{pane_id}$sep#{@bgj_session}$sep#{@bgj_name}$sep"
+    format+="#{pane_current_command}$sep#{pane_dead}$sep#{pane_dead_status}$sep#{@bgj_at}"
+
+    tmux list-panes -s -t "=$holder" -F "$format" 2>/dev/null \
+        | while IFS=$sep read -r id origin name cmd dead dead_status since; do
+            # Panes without metadata are not jobs, e.g. a holder placeholder
+            [[ -z $origin ]] && continue
+            [[ $scope != all && $origin != "$scope" ]] && continue
+            printf '%s\n' "$id$sep$origin$sep$name$sep$cmd$sep$dead$sep$dead_status$sep$since"
+        done
+}
+
+# Drop shell state files belonging to panes that no longer exist
+prune() {
+    local live f pane
+    [[ -d $state_dir ]] || return 0
+    live=$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null) || return 0
+    for f in "$state_dir"/%*; do
+        [[ -e $f ]] || continue
+        pane=${f##*/}
+        grep -qxF -- "$pane" <<<"$live" || rm -f "$f"
+    done
+    return 0
+}
+
+placeholder=""
+ensure_holder() {
+    local width=$1 height=$2
+    tmux has-session -t "=$holder" 2>/dev/null && return 0
+    placeholder=$(tmux new-session -d -P -F '#{window_id}' -s "$holder" -x "$width" -y "$height")
+}
+
+cmd_send() {
+    local pane=${1:-$(tmux display -p '#{pane_id}')}
+    local session window name path width height panes layout replacement format
+
+    format="#{session_name}$sep#{window_id}$sep#{window_name}$sep#{pane_current_path}"
+    format+="$sep#{window_width}$sep#{window_height}$sep#{window_panes}"
+
+    IFS=$sep read -r session window name path width height panes < <(
+        tmux display -p -t "$pane" "$format"
+    )
+
+    if [[ $session == "$holder" ]]; then
+        tmux display-message "already a background job"
+        return 0
+    fi
+
+    ensure_holder "$width" "$height"
+
+    if ((panes > 1)); then
+        # Grow a replacement into the slot before moving the original out so
+        # the surrounding layout can be restored verbatim
+        layout=$(tmux display -p -t "$window" '#{window_layout}')
+        if tmux split-window -d -t "$pane" -c "$path" 2>/dev/null; then
+            tmux break-pane -d -a -n "$name" -s "$pane" -t "=$holder:"
+            tmux select-layout -t "$window" "$layout" 2>/dev/null || true
+        else
+            tmux break-pane -d -a -n "$name" -s "$pane" -t "=$holder:"
+        fi
+    else
+        # Create the replacement first: breaking the only pane of the only
+        # window would destroy the session and detach the client
+        replacement=$(tmux new-window -d -P -F '#{window_id}' -a -t "$window" -n "$name" -c "$path")
+        tmux break-pane -d -a -n "$name" -s "$pane" -t "=$holder:"
+        # break-pane does not trigger renumber-windows, so the replacement
+        # only slides into the original index once we renumber explicitly
+        tmux move-window -r -t "=$session:"
+        tmux select-window -t "$replacement"
+    fi
+
+    # Detached sessions size windows from default-size (80x24), which would
+    # squash the job. Pin it to the geometry it had in the foreground.
+    tmux resize-window -t "$pane" -x "$width" -y "$height"
+
+    tmux set -p -t "$pane" @bgj_session "$session"
+    tmux set -p -t "$pane" @bgj_name "$name"
+    tmux set -p -t "$pane" @bgj_at "$EPOCHSECONDS"
+
+    [[ -n $placeholder ]] && tmux kill-window -t "$placeholder"
+
+    tmux refresh-client -S
+    tmux display-message "backgrounded $name"
+}
+
+cmd_list() {
+    local scope=${1:-} id origin name cmd dead dead_status since display
+
+    if [[ -z $scope ]]; then
+        scope=${BGJ_SESSION:-}
+        [[ -r $scope_file && $(<"$scope_file") == all ]] && scope=all
+    fi
+    [[ -z $scope ]] && scope=all
+
+    prune
+
+    records "$scope" | while IFS=$sep read -r id origin name cmd dead dead_status since; do
+        read_state "$id" "$dead" "$dead_status" "$cmd" "$since"
+        display=$(printf '%s %-14.14s %-10.10s' "$job_icon" "$name" "$origin")
+        printf '%s\t%s%s%s %s\n' "$id" "$job_colour" "$display" "$c_reset" "$job_detail"
+    done
+}
+
+cmd_ui() {
+    local session=${1:-$(tmux display -p '#{session_name}')}
+    local window=${2:-$(tmux display -p '#{window_id}')}
+    local out key pane
+
+    export BGJ_SESSION="$session"
+    mkdir -p "$state_dir"
+    printf 'session' >"$scope_file"
+
+    if [[ -z $(cmd_list "$session") ]]; then
+        tmux display-message "no background jobs in $session"
+        return 0
+    fi
+
+    out=$(
+        cmd_list "$session" | fzf-tmux -p 70%,60% \
+            --delimiter='\t' --with-nth=2 --accept-nth=1 \
+            --layout=reverse --no-sort --ansi \
+            --border-label ' background ' --prompt '⚙  ' \
+            --header '  ^a all  ^s session  ^j split  ^d kill' \
+            --expect=ctrl-j \
+            --preview 'tmux capture-pane -pe -t {1} -S -200' \
+            --preview-window 'down,60%' \
+            --bind 'tab:down,btab:up' \
+            --bind "ctrl-a:execute-silent(printf all > '$scope_file')+reload(tmux-bg list)" \
+            --bind "ctrl-s:execute-silent(printf session > '$scope_file')+reload(tmux-bg list)" \
+            --bind 'ctrl-d:execute-silent(tmux kill-window -t {1})+reload(tmux-bg list)'
+    ) || return 0
+
+    key=$(sed -n 1p <<<"$out")
+    pane=$(sed -n 2p <<<"$out")
+    [[ -z $pane ]] && return 0
+
+    if [[ $key == ctrl-j ]]; then
+        cmd_join "$pane" "$window"
+    else
+        cmd_restore "$pane" "$window"
+    fi
+}
+
+# Undo the size pin and metadata before a job rejoins a visible session
+unpin() {
+    local pane=$1
+    tmux set -w -u -t "$pane" window-size
+    tmux set -p -u -t "$pane" @bgj_session
+    tmux set -p -u -t "$pane" @bgj_name
+    tmux set -p -u -t "$pane" @bgj_at
+}
+
+cmd_restore() {
+    local pane=$1
+    local window=${2:-$(tmux display -p '#{window_id}')}
+    local session
+
+    session=$(tmux display -p -t "$window" '#{session_name}')
+
+    unpin "$pane"
+    tmux move-window -a -s "$pane" -t "$window"
+    tmux move-window -r -t "=$session:"
+    tmux select-window -t "$pane"
+    tmux refresh-client -S
+}
+
+cmd_join() {
+    local pane=$1
+    local window=${2:-$(tmux display -p '#{window_id}')}
+
+    unpin "$pane"
+    tmux join-pane -v -s "$pane" -t "$window"
+    tmux refresh-client -S
+}
+
+cmd_kill() {
+    tmux kill-window -t "$1"
+    tmux refresh-client -S
+}
+
+# Compact status line segment: job count, highlighted when one is waiting
+cmd_status() {
+    local scope=${1:-} id origin name cmd dead dead_status since
+    local -i total=0 waiting=0
+
+    [[ -z $scope ]] && return 0
+
+    while IFS=$sep read -r id origin name cmd dead dead_status since; do
+        [[ -z $id ]] && continue
+        total+=1
+        read_state "$id" "$dead" "$dead_status" "$cmd" ""
+        if ((job_done)); then
+            waiting+=1
+        fi
+    done < <(records "$scope")
+
+    ((total == 0)) && return 0
+
+    if ((waiting)); then
+        printf '#[fg=pink]⚙%d#[default] ' "$total"
+    else
+        printf '#[fg=gray]⚙%d#[default] ' "$total"
+    fi
+}
+
+subcommand=${1:-ui}
+(($#)) && shift
+
+case $subcommand in
+    send) cmd_send "$@" ;;
+    list) cmd_list "$@" ;;
+    ui) cmd_ui "$@" ;;
+    restore) cmd_restore "$@" ;;
+    join) cmd_join "$@" ;;
+    kill) cmd_kill "$@" ;;
+    status) cmd_status "$@" ;;
+    *)
+        printf 'usage: tmux-bg {send|list|ui|restore|join|kill|status} [args]\n' >&2
+        exit 1
+        ;;
+esac

--- a/bin/tmux/tmux-status-right
+++ b/bin/tmux/tmux-status-right
@@ -15,11 +15,11 @@ if git status | grep -q 'Your branch is ahead of'; then
     unpushed=true
 fi
 
-status=''
+status=$(tmux-bg status "$1") || status=''
 branch=$(git branch --show-current 2>/dev/null)
 
 if $changes; then
-    status='#[fg=pink]*#[default]'
+    status="$status#[fg=pink]*#[default]"
 fi
 
 if $unpushed; then

--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -35,7 +35,7 @@ set -g status-left-style "fg=gray"
 set -g status-left "#S"
 set -g status-left-length 30
 
-set -g status-right '#(tmux-status-right)'
+set -g status-right '#(tmux-status-right #{session_name})'
 
 set-hook -g client-session-changed 'refresh-client -S'
 set -g status-interval 5
@@ -107,6 +107,13 @@ bind-key 'z' confirm-before 'respawn-window -k'
 
 bind-key 'J' swap-window -d -t +1
 bind-key 'K' swap-window -d -t -1
+
+# Background jobs
+# Panes are parked in a hidden '_bg' session, so they keep running but drop
+# out of the status bar and out of next/previous-window
+
+bind -N "background this pane" 'b' run-shell 'tmux-bg send #{pane_id}'
+bind -N "list background jobs" 'B' run-shell 'tmux-bg ui #{session_name} #{window_id}'
 
 # set -g detach-on-destroy off
 

--- a/opt/sessionizer/sessions.go
+++ b/opt/sessionizer/sessions.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 )
 
+// Holding session for backgrounded panes, managed by tmux-bg. It is never
+// meant to be attached to, so it must not show up as a switchable session.
+const hiddenSession = "_bg"
+
 func loadSessions() (sessionItems []*session.Session) {
 	cfg := config.Load()
 
@@ -31,6 +35,9 @@ func loadSessions() (sessionItems []*session.Session) {
 	if err == nil {
 		for _, line := range strings.Split(sessionsText, "\n") {
 			tmuxSessionItem := tmuxsession.NewFromLine(line)
+			if tmuxSessionItem.Name == "" || tmuxSessionItem.Name == hiddenSession {
+				continue
+			}
 			sessionItems = mergeInTmuxSession(sessionItems, tmuxSessionItem)
 		}
 	}

--- a/opt/sessionizer/tmuxsession/tmuxsession.go
+++ b/opt/sessionizer/tmuxsession/tmuxsession.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const LineFormat = "#{session_last_attached} #{session_name} #{session_path}"
+// session_last_attached is empty for sessions that were never attached, which
+// would leave a leading space that gets trimmed away with the rest of the
+// output and shift every field of the first line
+const LineFormat = "#{?session_last_attached,#{session_last_attached},0} #{session_name} #{session_path}"
 
 type TmuxSession struct {
 	Name         string
@@ -13,8 +16,13 @@ type TmuxSession struct {
 	LastAttached int
 }
 
+// NewFromLine parses a LineFormat line. A session with an empty Name means the
+// line was malformed and should be skipped.
 func NewFromLine(line string) TmuxSession {
 	parts := strings.SplitN(line, " ", 3)
+	if len(parts) < 3 {
+		return TmuxSession{}
+	}
 
 	lastAttached, _ := strconv.Atoi(parts[0])
 

--- a/sh/zshrc.d/46-tmux-jobs.zsh
+++ b/sh/zshrc.d/46-tmux-jobs.zsh
@@ -1,0 +1,34 @@
+#!/usr/bin/env zsh
+# Record command state per tmux pane so tmux-bg can report background jobs
+
+[[ -n $TMUX_PANE ]] || return
+
+zmodload zsh/datetime
+autoload -Uz add-zsh-hook
+
+_tmux_jobs_dir="$HOME/.local/state/tmux-jobs"
+_tmux_jobs_file="$_tmux_jobs_dir/$TMUX_PANE"
+
+[[ -d $_tmux_jobs_dir ]] || mkdir -p $_tmux_jobs_dir
+
+# kind US timestamp US exit US duration US command
+# US instead of tab so that empty fields survive being read back by tmux-bg.
+# Written with a builtin redirect only, no forks and no tmux calls.
+_tmux_jobs_sep=$'\x1f'
+
+_tmux_jobs_preexec() {
+    _tmux_jobs_start=$EPOCHSECONDS
+    _tmux_jobs_cmd=${1//$'\x1f'/ }
+    print -r -- "R$_tmux_jobs_sep$EPOCHSECONDS$_tmux_jobs_sep$_tmux_jobs_sep$_tmux_jobs_sep$_tmux_jobs_cmd" >$_tmux_jobs_file
+}
+add-zsh-hook preexec _tmux_jobs_preexec
+
+# Runs after _prompt_precmd (45-prompt.zsh), which owns $_prompt_status.
+# $? is unreliable here because the earlier hook has already clobbered it.
+_tmux_jobs_precmd() {
+    [[ -n $_tmux_jobs_cmd ]] || return
+    local dur=$((EPOCHSECONDS - _tmux_jobs_start))
+    print -r -- "D$_tmux_jobs_sep$EPOCHSECONDS$_tmux_jobs_sep${_prompt_status:-0}$_tmux_jobs_sep$dur$_tmux_jobs_sep$_tmux_jobs_cmd" >$_tmux_jobs_file
+    unset _tmux_jobs_cmd
+}
+add-zsh-hook precmd _tmux_jobs_precmd


### PR DESCRIPTION
Send a pane to the background with `prefix b`, list and bring back background jobs with `prefix B`.

## How it works

Backgrounded panes are moved into a hidden holding session `_bg` with `break-pane -d`. Because the status bar only renders the current session's windows, they vanish from it for free, and they are also skipped by `next-window`/`previous-window`/`last-window` without touching any bindings. The pane keeps running, keeps its pane id and keeps its scrollback.

The alternative of keeping them in the same session with high indexes and a conditional `window-status-format` was rejected: `window-status-separator` is still emitted for empty entries, which breaks `status-justify absolute-centre`, and navigation and mouse clicks would need custom skip logic.

### `prefix b` — background the current pane

For a single-pane window the replacement window is created **before** `break-pane`. Backgrounding the only pane of the only window in a session would otherwise empty the session, destroy it and detach the client. `break-pane` does not trigger `renumber-windows`, so an explicit `move-window -r` slides the replacement into the original index. Result: same index, same name, same cwd, fresh shell.

For a multi-pane window a replacement pane is grown into the slot first, then the original is broken out and the saved `window_layout` is re-applied, so the surrounding layout is preserved exactly.

The job window is then pinned with `resize-window`. A detached session sizes windows from `default-size` (80x24), which would squash TUIs and wrap log output; the pin keeps the geometry the pane had in the foreground. It is undone on restore.

### `prefix B` — list and restore

fzf popup styled like the existing `prefix e` session picker, scoped to the current session by default, with `tmux capture-pane` as a live preview.

- `enter` restore as a window after the current one
- `^j` restore as a split in the current window
- `^a` / `^s` all jobs / current session only
- `^d` kill

### Knowing which jobs are done

Four signals, in precedence order:

| state | shown as |
|---|---|
| dead pane (`remain-on-exit` is on) | `† exited 7` |
| shell integration, running | `● make build · 2m13s` |
| shell integration, finished | `✓ make build · 20s · 7s ago` / `✗ … exit 1 …` |
| no data, `pane_current_command` is the shell | `○ idle · 5m in bg` |

The shell integration is a zsh `preexec`/`precmd` hook that writes one line to `~/.local/state/tmux-jobs/$TMUX_PANE`. Pane ids are stable for the life of the pane, so the key survives the move into `_bg`. It is a builtin redirect only — no forks, no `tmux` calls per prompt. Stale files are pruned against `list-panes -a` whenever the list is built.

It reads `$_prompt_status` from `45-prompt.zsh` rather than `$?`, because by the time a second `precmd` hook runs `$?` is the previous hook's status. `50-opts.zsh` already depends on this same ordering.

### Status bar

`status-right` gains a `⚙<n>` segment for the current session, gray while everything is still running and pink once a job has finished and is waiting. `status-right` now passes `#{session_name}` so the count can be scoped, and a latent bug where the git dirty marker overwrote the segment instead of appending was fixed.

`_bg` is filtered out of `sessionizer` so it never shows up in `prefix e` or `prefix w`.

## Testing

Verified against tmux 3.7b on a live server:

- single-pane background restores the exact index, name and cwd
- multi-pane background reproduces the pane geometry byte for byte
- backgrounding the only pane of the only window keeps a real attached client attached and the session alive
- restore unpins `window-size`, clears the metadata and preserves scrollback
- all four job states render correctly, including a `sleep 20; false` job reported as `✗ … exit 1 · 20s`
- `⚙` segment gray with only running jobs, pink once one finishes
- `_bg` is destroyed automatically when the last job leaves
- `tmux.conf` parses on a scratch server and both bindings register
- `shfmt`, `shellcheck`, `gofmt`, `go vet` clean

## Note

Restoring a job leaves the replacement window in place, so you can end up with two windows of the same name. That is deliberate — the replacement may have been used in the meantime and killing it could destroy work.