### PR TITLE
fix: ignore failed URL change checks

### DIFF
--- a/bin/all/wait-url-changes
+++ b/bin/all/wait-url-changes
@@ -2,17 +2,18 @@
 
 url=$1
 
-old=$(mktemp)
-new=$(mktemp)
+workdir=$(mktemp -d) || exit 1
+trap 'rm -rf "$workdir"' 0
+trap 'exit 1' HUP INT TERM
+
+old="$workdir/old"
+new="$workdir/new"
 
 # Baseline
-curl -s "$url" >"$new"
-curl -s "$url" >"$old"
+curl -fsS "$url" >"$old" || exit 1
 
 while true; do
-    curl -sf "$url" >"$new"
-
-    if ! cmp -s "$old" "$new"; then
+    if curl -fsS "$url" >"$new" && ! cmp -s "$old" "$new"; then
         exit 0
     fi
 


### PR DESCRIPTION
## Summary
- establish the comparison baseline with one successful request
- ignore transient request failures instead of reporting them as content changes
- clean up temporary comparison files on exit

## Testing
- `sh -n bin/all/wait-url-changes`
- `nix run nixpkgs#shfmt -- -d bin/all/wait-url-changes`
- `nix run nixpkgs#shellcheck -- -s sh bin/all/wait-url-changes`
- mocked functional checks for transient request failure, real content change, initial request failure, and temporary-file cleanup
- `nix run nixpkgs#gitleaks -- detect --no-git --source bin/all/wait-url-changes --redact --no-banner`
- `git diff --check`