### PR TITLE
fix: limit calculator evaluation time

### DIFF
--- a/bin/all/calc-ls
+++ b/bin/all/calc-ls
@@ -29,7 +29,7 @@ process.stdin.on("end", () => {
     }
 
     try {
-      const result = script.runInContext(context);
+      const result = script.runInContext(context, { timeout: 100 });
 
       if (result !== undefined) {
         diagnostics.push({


### PR DESCRIPTION
## Summary
- cap each calculator statement evaluation at 100 milliseconds
- prevent accidental or malformed infinite loops from hanging the calculator language server
- continue evaluating later statements after a timed-out calculation

## Testing
- `node --check bin/all/calc-ls`
- functional timeout regression: `while (true) {}` followed by `40 + 2` returns the second result within 2 seconds
- functional state regression: declarations remain available to later calculations
- `nix run nixpkgs#prettier -- --check bin/all/calc-ls`
- `nix run nixpkgs#gitleaks -- detect --no-git --source bin/all/calc-ls --redact --no-banner`
- `nix flake check --all-systems`
- `git diff --check`