### PR TITLE
Fix remote tmux session attachment

### DIFF
--- a/bin/tmux/remote-tmux-session
+++ b/bin/tmux/remote-tmux-session
@@ -31,4 +31,4 @@ tmux set-option -t "$TMUX_PANE" @remote-host "$host" \; \
     set-option -t "$TMUX_PANE" status off \; \
     set-option -t "$TMUX_PANE" mouse off
 
-exec ssh -t -- "$host" "exec \"\$SHELL\" -lc 'exec sessionizer connect $remote_session'"
+exec ssh -tt -- "$host" "exec \"\$SHELL\" -lc 'unset TMUX TMUX_PANE; exec sessionizer connect $remote_session'"


### PR DESCRIPTION
## Summary
- force SSH to allocate a remote PTY
- clear inherited tmux environment before invoking the remote sessionizer
- keep the remote session attached instead of returning to the previous local session

## Validation
- `shfmt`
- `bash -n bin/tmux/remote-tmux-session`
- `shellcheck bin/tmux/remote-tmux-session`
- `git diff --check`