### PR TITLE
fix: enable firewall and fail2ban in base, disable in base-home

### DIFF
--- a/nix/base-home/default.nix
+++ b/nix/base-home/default.nix
@@ -9,5 +9,6 @@
     };
 
     networking.firewall.enable = false;
+    services.fail2ban.enable = false;
   };
 }

--- a/nix/base/network.nix
+++ b/nix/base/network.nix
@@ -1,7 +1,8 @@
 {...}: {
-  flake.modules.nixos.base = {...}: {
+  flake.modules.nixos.base = {lib, ...}: {
     networking = {
       usePredictableInterfaceNames = false;
+      firewall.enable = lib.mkDefault true;
     };
   };
 }

--- a/nix/base/services/other.nix
+++ b/nix/base/services/other.nix
@@ -1,6 +1,6 @@
 {...}: {
-  flake.modules.nixos.base = {config, ...}: {
-    services.fail2ban.enable = config.networking.firewall.enable;
+  flake.modules.nixos.base = {lib, ...}: {
+    services.fail2ban.enable = lib.mkDefault true;
     services.fstrim.enable = true;
   };
 }

--- a/nix/base/services/other.nix
+++ b/nix/base/services/other.nix
@@ -1,6 +1,6 @@
 {...}: {
-  flake.modules.nixos.base = {...}: {
-    services.fail2ban.enable = true;
+  flake.modules.nixos.base = {config, ...}: {
+    services.fail2ban.enable = config.networking.firewall.enable;
     services.fstrim.enable = true;
   };
 }


### PR DESCRIPTION
## Summary
- `base` unconditionally enables the NixOS firewall and fail2ban (via `lib.mkDefault` so purpose modules can still override)
- `base-home` explicitly disables both firewall and fail2ban on home hosts
- removes the repeated `fail2ban can not be used without a firewall` evaluation warning and avoids running an ineffective fail2ban service on home hosts

## Testing
- `nix fmt -- nix/base/services/other.nix nix/base/network.nix nix/base-home/default.nix` (clean)
- `nix flake check` (all checks passed, no fail2ban warning)
- per-host evals of `services.fail2ban.enable` / `networking.firewall.enable`:
  - a5, ag, ix, l4, rt, tp (base-home): `false` / `false`
  - mt, pd: `true` / `true`