### PR TITLE
fix: disable forced ZFS import on installer ISO

### DIFF
--- a/nix/hosts/iso/default.nix
+++ b/nix/hosts/iso/default.nix
@@ -23,6 +23,8 @@
 
     nixpkgs.hostPlatform = "x86_64-linux";
 
+    boot.zfs.forceImportRoot = false;
+
     environment.systemPackages = [pkgs.vim];
   };
 }


### PR DESCRIPTION
## Summary
- disable forced ZFS root-pool import on the installer ISO
- follow the safer NixOS default and avoid importing a host pool during rescue or installation
- remove the Nix evaluation warning without changing installed host configurations

## Testing
- `nix fmt -- --check nix/hosts/iso/default.nix`
- `nix eval --json .#nixosConfigurations.iso.config.boot.zfs.forceImportRoot` (`false`)
- `nix flake check --all-systems`
- `nix run nixpkgs#gitleaks -- detect --no-git --source nix/hosts/iso/default.nix --redact --no-banner`
- `git diff --check`